### PR TITLE
Replace steebchen/nginx-spa with own config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Changed
+- Replaced `steebchen/nginx-spa` with `nginx:mainline-alpine` as it was breaking paths with dots (`.`) like `/account/eosio.token`. This also allowed adding gzip compression and Cache-Control headers.
 - Upgraded some webpack dependencies:
   - `mini-css-extract-plugin` from `1.3.4` to `1.3.5`
   - `webpack-cli` from `4.3.1` to `4.4.0`

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,6 @@ COPY . .
 RUN npm install
 RUN npm run build
 
-FROM steebchen/nginx-spa:latest
+FROM nginx:mainline-alpine
+COPY --from=build ./nginx/default.conf /etc/nginx/conf.d/
 COPY --from=build ./dist /app/
-RUN chmod -R 777 /app

--- a/nginx/README.md
+++ b/nginx/README.md
@@ -1,0 +1,13 @@
+# Nginx Configuration
+`default.conf` is a simple Nginx configuration for Single Page Applications (SPAs).
+
+Its main feature is the redirection of not found routes to `index.html`. In addition to that, it serves gzipped content and adds Cache-Control headers to application assets such as JavaScript and CSS files.
+
+When using Docker with an Nginx image, this configuration must be moved to an appropriate directory to be properly recognized. Example:
+
+```Dockerfile
+FROM nginx:mainline-alpine
+COPY ./nginx/default.conf /etc/nginx/conf.d/
+```
+
+This config directory might vary between image flavors so check your specific image documentation.

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -1,0 +1,40 @@
+server {
+    listen 80 default_server;
+
+    # Enable gzip compression of assets
+    gzip on;
+    gzip_disable "msie6";
+    gzip_comp_level 6;
+    gzip_min_length 1000;
+    gzip_buffers 16 8k;
+    gzip_proxied any;
+    gzip_types
+        text/plain
+        text/css
+        text/js
+        text/javascript
+        application/javascript
+        application/x-javascript
+        application/json
+        image/svg+xml;
+
+    # Do not include the nginx version with the Server response header.
+    server_tokens  off;
+
+    root /app;
+
+    # Default route.
+    # Serve the requested uri if available, else default to index.html.
+    location / {
+        # index.html should never be cached.
+        add_header Cache-Control "no-store";
+        try_files $uri $uri/index.html /index.html;
+    }
+
+    # Application assets.
+    location ~* /(css|js) {
+        # App assets are hashed and can be safely cached.
+        add_header Cache-Control "public, max-age=31536000";
+        try_files $uri =404;
+    }
+}


### PR DESCRIPTION
Steeb's Nginx configuration makes an assumption that the SPA will not manage user routes containing dots (`.`). This is problematic as the dot charater is part of the EOSIO name space (e.g. the `eosio.token` account).

Thus, this PR replaces `steebchen/nginx-spa` with the official Nginx image `nginx:mainline-alpine` using our own configuration. This configuration allows for paths containing dots to be redirected to `index.html` like any other path. In addition to that, it correctly applies gzip compression and Cache-Control headers.