### PR TITLE
Fix localization strings using nesting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Localization strings using nesting not displaying correctly.
 
 ## [0.2.2] - 2021-03-06
 ### Changed

--- a/src/home/home.tsx
+++ b/src/home/home.tsx
@@ -87,17 +87,17 @@ const ChainInfo: React.FC<ChainInfoProps> = ({ info }) => {
 
   return (
     <div>
-      <p>{t('home.chainInfo.chainId', { id: chain_id })}</p>
-      <p>{t('home.chainInfo.headBlock', { num: head_block_num, id: head_block_id })}</p>
+      <p>{t('chainInfo.chainId', { id: chain_id })}</p>
+      <p>{t('chainInfo.headBlock', { num: head_block_num, id: head_block_id })}</p>
       <p>
-        {t('home.chainInfo.headBlockProducerHeading')}
+        {t('chainInfo.headBlockProducerHeading')}
         {': '}
         <Link to={`/account/${head_block_producer}`}>{head_block_producer}</Link>
       </p>
       <p>
         Head block time: {head_block_time}
       </p>
-      <p>{t('home.chainInfo.lastIrreversibleBlock', {
+      <p>{t('chainInfo.lastIrreversibleBlock', {
         num: last_irreversible_block_num,
         id: last_irreversible_block_id,
       })}</p>

--- a/src/localization/locales/en-us/home.json
+++ b/src/localization/locales/en-us/home.json
@@ -5,13 +5,13 @@
   },
   "chainInfo": {
     "chainIdHeading": "Chain id",
-    "chainId": "$t(home.chainInfo.chainIdHeading): {{id}}",
+    "chainId": "$t(chainInfo.chainIdHeading): {{id}}",
     "headBlockHeading": "Head block",
-    "headBlock": "$t(home.chainInfo.headBlockHeading): {{num}} ({{id}})",
+    "headBlock": "$t(chainInfo.headBlockHeading): {{num}} ({{id}})",
     "headBlockProducerHeading": "Head block producer",
     "headBlockTimeHeading": "Head block time",
     "lastIrreversibleBlockHeading": "Last Irreversible block",
-    "lastIrreversibleBlock": "$t(home.chainInfo.lastIrreversibleBlockHeading): {{num}} ({{id}})"
+    "lastIrreversibleBlock": "$t(chainInfo.lastIrreversibleBlockHeading): {{num}} ({{id}})"
   },
   "error": "Something went wrong when retrieving chain info.",
   "loading": "Loading…"

--- a/src/localization/locales/en-us/settings.json
+++ b/src/localization/locales/en-us/settings.json
@@ -6,10 +6,10 @@
   "info": {
     "heading": "Info",
     "versionHeading": "Head block",
-    "version": "$t(settings.info.versionHeading): {{version}}",
+    "version": "$t(info.versionHeading): {{version}}",
     "buildHashHeading": "Build hash",
-    "buildHash": "$t(settings.info.buildHashHeading): {{hash}}",
+    "buildHash": "$t(info.buildHashHeading): {{hash}}",
     "buildTimeHeading": "Build time",
-    "buildTime": "$t(settings.info.buildTimeHeading): {{time}}"
+    "buildTime": "$t(info.buildTimeHeading): {{time}}"
   }
 }


### PR DESCRIPTION
It seems that recently i18next changed its behavior so that strings using nesting **don't** need to use a top-level namespace when
referencing other strings. This seems to be an undocumented change or perhaps there is no documentation because it is a regression.

Future i18next package upgrades must be inspected with more caution.